### PR TITLE
Fix UDPSpectrum for Python 3

### DIFF
--- a/spectrum/handlers/udp.py
+++ b/spectrum/handlers/udp.py
@@ -60,4 +60,4 @@ class UDPSpectrum(BaseSpectrumHandler):
             self.post(message)
 
     def post(self, message):
-        self.sock.sendall(json.dumps(message))
+        self.sock.sendall(json.dumps(message).encode())

--- a/spectrum/handlers/udp.py
+++ b/spectrum/handlers/udp.py
@@ -60,4 +60,4 @@ class UDPSpectrum(BaseSpectrumHandler):
             self.post(message)
 
     def post(self, message):
-        self.sock.sendall(json.dumps(message).encode())
+        self.sock.sendall(json.dumps(message).encode('utf8'))


### PR DESCRIPTION
Can only send bytes to a socket, not a unicode string:

``` python
Traceback (most recent call last):
  ...
  File "/Users/tomkins/Python/spectrum-python/spectrum/handlers/udp.py", line 60, in emit
    self.post(message)
  File "/Users/tomkins/Python/spectrum-python/spectrum/handlers/udp.py", line 63, in post
    self.sock.sendall(json.dumps(message))
TypeError: a bytes-like object is required, not 'str'
```
