### PR TITLE
Untitled sublevels

### DIFF
--- a/spectrum/django/spectrum.py
+++ b/spectrum/django/spectrum.py
@@ -47,7 +47,6 @@ FIRE_HOSE = {
         'root': {
             'level': 'DEBUG',
             'class': 'spectrum.handlers.RestSpectrum',
-            'sublevel': '',
             'filters': ['request_id']
         },
         'django': {
@@ -125,7 +124,6 @@ FIRE_HOSE_UDP = {
         'root': {
             'level': 'DEBUG',
             'class': 'spectrum.handlers.UDPSpectrum',
-            'sublevel': '',
         },
         'django': {
             'level': 'DEBUG',
@@ -199,7 +197,6 @@ FIRE_HOSE_WS = {
         'root': {
             'level': 'DEBUG',
             'class': 'spectrum.handlers.WebsocketSpectrum',
-            'sublevel': '',
         },
         'django': {
             'level': 'DEBUG',

--- a/spectrum/handlers/base.py
+++ b/spectrum/handlers/base.py
@@ -8,13 +8,13 @@ class BaseSpectrumHandler(logging.Handler):
     def __init__(self, sublevel=None, *args, **kwargs):
         self.sublevel = sublevel
 
-        if self.sublevel is None:
-            self.sublevel = 'None'
-
         super(BaseSpectrumHandler, self).__init__(*args, **kwargs)
 
     def get_sub_level(self, record):
-        return self.sublevel
+        if self.sublevel is not None:
+            return self.sublevel
+        else:
+            return record.name
 
     def build_message(self, record):
         return {

--- a/spectrum/handlers/udp.py
+++ b/spectrum/handlers/udp.py
@@ -29,11 +29,6 @@ class UDPSpectrum(BaseSpectrumHandler):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.connect((self.UDP_IP, self.UDP_PORT))
 
-        self.sublevel = sublevel
-
-        if self.sublevel is None:
-            self.sublevel = 'None'
-
         super(UDPSpectrum, self).__init__(sublevel, *args, **kwargs)
 
     def emit(self, record):


### PR DESCRIPTION
I'm guessing this is possibly intentional, however for a firehose of logging, it's hard to filter log entries which are untitled:

```
DEBUG: <untitled> - "GET /api/0/organizations/ HTTP/1.1" 200 None
```

Currently spectrum-python forces you to add a logging handler for every log name just to have a sublevel title. It seems a bit long winded having to do this when Python gives a log name for every record anyway.
