### PR TITLE
Logging fix for requests >= 2.10.0

### DIFF
--- a/spectrum/filters.py
+++ b/spectrum/filters.py
@@ -5,4 +5,4 @@ from .conf import SPECTRUM_UUID4
 
 class RequestIdFilter(logging.Filter):
     def filter(self, record):
-        return "POST /?spectrum=%s" % SPECTRUM_UUID4 not in record.msg
+        return "POST /?spectrum=%s" % SPECTRUM_UUID4 not in record.getMessage()


### PR DESCRIPTION
The format of the debug log message changed in an updated version of urllib3 from requests.

[requests 2.9.2](https://github.com/kennethreitz/requests/blob/v2.9.2/requests/packages/urllib3/connectionpool.py#L385):

```python
log.debug("\"%s %s %s\" %s %s" % (method, url, http_version,
                                  httplib_response.status,
                                  httplib_response.length))
```

[requests 2.10.0](https://github.com/kennethreitz/requests/blob/v2.10.0/requests/packages/urllib3/connectionpool.py#L394):

```python
log.debug("\"%s %s %s\" %s %s", method, url, http_version,
          httplib_response.status, httplib_response.length)
```

Latest version of requests adds a bit more to the message as well - but this patch works just fine.